### PR TITLE
Add tolerance parameter to solution object

### DIFF
--- a/src/ppopt/__init__.py
+++ b/src/ppopt/__init__.py
@@ -1,5 +1,3 @@
-"""PPOPT INIT FILE"""
-"""Main __init__.py for the ppopt package"""
 import os
 
 os.environ["OMP_NUM_THREADS"] = "1"  # export OMP_NUM_THREADS=1

--- a/src/ppopt/critical_region.py
+++ b/src/ppopt/critical_region.py
@@ -79,10 +79,10 @@ class CriticalRegion:
         """Evaluates λ(θ) = Cθ + d."""
         return self.C @ theta + self.d
 
-    def is_inside(self, theta: numpy.ndarray) -> numpy.ndarray:
+    def is_inside(self, theta: numpy.ndarray, tol: float = 1e-5) -> numpy.ndarray:
         """Tests if point θ is inside the critical region."""
         # check if all constraints EΘ <= f
-        return numpy.all(self.E @ theta - self.f < 0)
+        return numpy.all(self.E @ theta - self.f < tol)
 
     # depreciated
     def is_full_dimension(self) -> bool:

--- a/src/ppopt/solution.py
+++ b/src/ppopt/solution.py
@@ -20,17 +20,19 @@ class Solution:
     critical_regions: List[CriticalRegion]
 
     def __init__(self, program: Union[MPLP_Program, MPQP_Program], critical_regions: List[CriticalRegion],
-                 is_overlapping=False):
+                 is_overlapping=False, point_location_tolerance=1e-5):
         """
         The explicit solution associated with
 
         :param program: The multiparametric program that is considered here
         :param critical_regions: The list of critical regions in the solution
         :param is_overlapping: A Flag that tells the point location routine that there are overlapping critical regions
+        :param point_location_tolerance: The point location tolerance used to determine the critical regions
         """
         self.program = program
         self.critical_regions = critical_regions
         self.is_overlapping = is_overlapping
+        self.point_location_tolerance = point_location_tolerance
 
     def add_region(self, region: CriticalRegion) -> None:
         """
@@ -80,7 +82,7 @@ class Solution:
         :return: the critical region that contains theta_point or None
         """
         for region in self.critical_regions:
-            if region.is_inside(theta_point):
+            if region.is_inside(theta_point, self.point_location_tolerance):
                 return region
         return None
 
@@ -98,7 +100,7 @@ class Solution:
 
         for region in self.critical_regions:
             # check if theta is inside the critical region
-            if region.is_inside(theta_point):
+            if region.is_inside(theta_point, self.point_location_tolerance):
                 # we are inside the critical region now evaluate x* and f*
                 x_star = region.evaluate(theta_point)
                 obj = self.program.evaluate_objective(x_star, theta_point)

--- a/tests/mpmiqp_solver_tests/test_mpmiqp.py
+++ b/tests/mpmiqp_solver_tests/test_mpmiqp.py
@@ -4,7 +4,7 @@ import numpy
 
 from src.ppopt.mp_solvers.solve_mpmiqp import solve_mpmiqp
 from src.ppopt.mpmilp_program import MPMILP_Program
-from tests.test_fixtures import simple_mpMILP, simple_mpMIQP
+from tests.test_fixtures import simple_mpMILP, simple_mpMIQP, mpMILP_market_problem
 
 
 def test_mpmilp_process_constraints(simple_mpMILP):
@@ -48,14 +48,29 @@ def test_mpmilqp_enumeration_solve(simple_mpMIQP):
 
     sol = solve_mpmiqp(simple_mpMIQP)
 
-def test_mpmilp_evaluate(simple_mpMILP):
+def test_mpmilp_evaluate(mpMILP_market_problem):
 
-    sol = solve_mpmiqp(simple_mpMILP)
+    # find the explicit solution to the mpMILP market problem
+    sol = solve_mpmiqp(mpMILP_market_problem)
 
-    sol.evaluate(numpy.array([[1.2]]))
+    # simple test that we are not finding a hole in the middle of two regions
+    theta_point = numpy.array([[0.0], [500.0]])
+
+    # get the solution
+    ppopt_solution = sol.evaluate(theta_point).flatten()
+    ppopt_value = sol.evaluate_objective(theta_point)
+
+    # get the deterministic solution
+    det_solution = mpMILP_market_problem.solve_theta(theta_point)
+    det_primal_sol = numpy.array(det_solution.sol)
+
+    assert(numpy.isclose(det_solution.obj, ppopt_value))
+    assert(all(numpy.isclose(det_primal_sol, ppopt_solution.flatten())))
+
 
 def test_mpmiqp_evaluate(simple_mpMIQP):
 
     sol = solve_mpmiqp(simple_mpMIQP)
 
     sol.evaluate(numpy.array([[1.2]]))
+

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -215,3 +215,22 @@ def simple_mpMIQP():
 
     mpmiqp = MPMIQP_Program(A, b, c, H, Q, A_t, b_t, F, binary_indices=[1, 2])
     return mpmiqp
+
+
+@pytest.fixture()
+def mpMILP_market_problem():
+    """Simple mpMILP for Seatle-to-Topeka"""
+
+    A = numpy.array(
+        [[1, 1, 0, 0, 0], [0, 0, 1, 1, 0], [-1, 0, -1, 0, 0], [0, -1, 0, -1, -500], [-1, 0, 0, 0, 0], [0, -1, 0, 0, 0],
+         [0, 0, -1, 0, 0], [0, 0, 0, -1, 0], [0, 0, 0, 0, -1], [0, 0, 0, 0, 1]], float)
+    b = numpy.array([350, 600, 0, 0, 0, 0, 0, 0, 0, 1], float).reshape(-1, 1)
+    F = numpy.array([[0, 0], [0, 0], [-1, 0], [0, -1], [0, 0], [0, 0], [0, 0], [0, 0], [0, 0], [0, 0]], float)
+    A_t = numpy.array([[1.0, 0.0], [0.0, 1.0], [-1.0, 0.0], [0.0, -1.0]], float)
+    b_t = numpy.array([[1000.0], [1000.0], [0.0], [0.0]], float)
+    H = numpy.zeros([5, 2])
+    c = numpy.array([178, 187, 187, 151, 50000]).reshape(-1, 1)
+    binary_indices = [4]
+
+    milp_prog = MPMILP_Program(A, b, c, H, A_t, b_t, F, binary_indices)
+    return milp_prog


### PR DESCRIPTION
Fixes odd behavior on where if a theta point is specified on the boundary of a critical region, there is no numerical forgiveness for being outside of the region. Now there is a parameter attached to the explicit solution object that allows for this closes #26.

Changes: Adds a tolerance parameter to the Solution object

