### PR TITLE
Fix case of overdetermined equality constraints

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-__version__ = "1.6.0"
+__version__ = "1.6.1"
 
 short_desc = (
     "Extensible Multiparametric Solver in Python"

--- a/src/ppopt/mp_solvers/mpqp_combi_graph.py
+++ b/src/ppopt/mp_solvers/mpqp_combi_graph.py
@@ -77,7 +77,10 @@ def solve(program: MPQP_Program) -> Solution:
     :return: the solution of the MPQP
     """
     # initialize with and Exclusion set, a base solution, and a set of things to visit
-    E, solution, S = combinatorial_graph_initialization(program, None)
+
+    initial_active_set = None if program.equality_indices is [] else [program.equality_indices]
+
+    E, solution, S = combinatorial_graph_initialization(program, initial_active_set)
 
     # make sure that everything we have added to S is in E
     for s in S:

--- a/src/ppopt/mp_solvers/mpqp_combi_graph.py
+++ b/src/ppopt/mp_solvers/mpqp_combi_graph.py
@@ -1,5 +1,6 @@
 import numpy
 
+from ..mplp_program import MPLP_Program
 from ..mpqp_program import MPQP_Program
 from ..solution import Solution
 from ..utils.constraint_utilities import is_full_rank
@@ -119,8 +120,16 @@ def solve(program: MPQP_Program) -> Solution:
         # if we fail LINQ then we need to remove a constraint to hope to be full rank
         if not is_full_rank(program.A, list(A)):
             explore_subset(A)
+
         # if we are full rank, check if the resulting critical region is not empty
         elif feasability_check(program, A):
+
+            # in the case of mpLPs the active set must have the same size as the number of x variables
+            if type(program) is MPLP_Program and len(A) != program.num_x():
+                # adds the super, and subsets
+                explore_subset(A)
+                explore_superset(A)
+                continue
 
             # Attempts to construct the region
             cand_region = gen_cr_from_active_set(program, list(A))

--- a/src/ppopt/mp_solvers/mpqp_combi_graph.py
+++ b/src/ppopt/mp_solvers/mpqp_combi_graph.py
@@ -78,9 +78,9 @@ def solve(program: MPQP_Program) -> Solution:
     """
     # initialize with and Exclusion set, a base solution, and a set of things to visit
 
-    initial_active_set = None if program.equality_indices is [] else [program.equality_indices]
+    # initial_active_set = None if program.equality_indices is [] else [program.equality_indices]
 
-    E, solution, S = combinatorial_graph_initialization(program, initial_active_set)
+    E, solution, S = combinatorial_graph_initialization(program, None)
 
     # make sure that everything we have added to S is in E
     for s in S:

--- a/src/ppopt/mp_solvers/mpqp_parrallel_graph.py
+++ b/src/ppopt/mp_solvers/mpqp_parrallel_graph.py
@@ -5,7 +5,6 @@ from ..mpqp_program import MPQP_Program
 from ..solution import Solution
 from ..utils.general_utils import num_cpu_cores
 from ..utils.mpqp_utils import gen_cr_from_active_set
-
 from .solver_utils import (
     CombinationTester,
     generate_extra,

--- a/src/ppopt/mplp_program.py
+++ b/src/ppopt/mplp_program.py
@@ -9,8 +9,9 @@ from .utils.constraint_utilities import (
     constraint_norm,
     find_implicit_equalities,
     find_redundant_constraints,
+    generate_reduced_equality_constraints,
     is_full_rank,
-    process_program_constraints, generate_reduced_equality_constraints,
+    process_program_constraints,
 )
 from .utils.general_utils import (
     latex_matrix,

--- a/src/ppopt/mplp_program.py
+++ b/src/ppopt/mplp_program.py
@@ -10,7 +10,7 @@ from .utils.constraint_utilities import (
     find_implicit_equalities,
     find_redundant_constraints,
     is_full_rank,
-    process_program_constraints,
+    process_program_constraints, generate_reduced_equality_constraints,
 )
 from .utils.general_utils import (
     latex_matrix,
@@ -36,6 +36,8 @@ def calc_weakly_redundant(A, b, equality_set: Optional[List[int]] = None, determ
 
 
 # noinspection GrazieInspection
+
+
 class MPLP_Program:
     r"""
     The standard class for multiparametric  linear programming
@@ -121,6 +123,7 @@ class MPLP_Program:
         # ensures that
         self.warnings()
         self.process_constraints()
+        print('POST PROCESS')
 
     def num_x(self) -> int:
         """Returns number of parameters."""
@@ -275,7 +278,7 @@ class MPLP_Program:
         """Removes redundant constraints from the multiparametric programming problem."""
         self.constraint_datatype_conversion()
 
-        # TODO: add check for a purly parametric euqaility e.g. c^T theta = b in the main constraint body
+        # TODO: add check for a purly parametric equality e.g. c^T theta = b in the main constraint body
         self.A, self.b, self.F, self.A_t, self.b_t = process_program_constraints(self.A, self.b, self.F, self.A_t,
                                                                                  self.b_t)
 
@@ -285,6 +288,11 @@ class MPLP_Program:
         # find implicit inequalities in the main constraint body, add them to the equality constraint set
         self.A, self.b, self.F, self.equality_indices = find_implicit_equalities(self.A, self.b, self.F,
                                                                                  self.equality_indices)
+
+        # in the case of equality constraints, there can be cases where the constraints are redundant w.r.t. each other
+        self.A, self.b, self.F, self.equality_indices = generate_reduced_equality_constraints(self.A, self.b, self.F,
+                                                                                               self.equality_indices)
+
 
         # form a polytope P := {(x, theta) in R^K : Ax <= b + F theta and A_t theta <= b_t}
         problem_A = ppopt_block([[self.A, -self.F], [numpy.zeros((self.A_t.shape[0], self.A.shape[1])), self.A_t]])

--- a/src/ppopt/mplp_program.py
+++ b/src/ppopt/mplp_program.py
@@ -71,7 +71,7 @@ class MPLP_Program:
 
     solver: Solver
 
-    def __init__(self, A, b, c, H, A_t, b_t, F, c_c=None, c_t=None, Q_t=None, equality_indices=None, solver=None):
+    def __init__(self, A, b, c, H, A_t, b_t, F, c_c=None, c_t=None, Q_t=None, equality_indices=None, solver=None, post_process = True):
 
         self.A = A
         self.b = b
@@ -107,7 +107,10 @@ class MPLP_Program:
 
         self.solver = solver
 
-    def __post_init__(self):
+        if post_process:
+            self.post_process()
+
+    def post_process(self):
         """Called after __init__ this is used as a post-processing step after the dataclass generated __init__."""
         if self.equality_indices is None:
             self.equality_indices = []
@@ -123,7 +126,6 @@ class MPLP_Program:
         # ensures that
         self.warnings()
         self.process_constraints()
-        print('POST PROCESS')
 
     def num_x(self) -> int:
         """Returns number of parameters."""

--- a/src/ppopt/mpmilp_program.py
+++ b/src/ppopt/mpmilp_program.py
@@ -52,20 +52,24 @@ class MPMILP_Program(MPLP_Program):
                  b_t: numpy.ndarray, F: numpy.ndarray, binary_indices=None, c_c: Optional[numpy.ndarray] = None,
                  c_t: Optional[numpy.ndarray] = None, Q_t: Optional[numpy.ndarray] = None,
                  equality_indices: Optional[List[int]] = None,
-                 solver: Solver = None):
+                 solver: Solver = None, post_process=True):
         """Initializes the MPMILP_Program"""
 
         if solver is None:
             solver = Solver()
 
-        super().__init__(A, b, c, H, A_t, b_t, F, c_c, c_t, Q_t, equality_indices, solver)
         self.binary_indices = binary_indices
+
+        super().__init__(A, b, c, H, A_t, b_t, F, c_c, c_t, Q_t, equality_indices, solver, post_process=False)
         self.cont_indices = [i for i in range(self.num_x()) if i not in self.binary_indices]
 
         if len(self.cont_indices) == 0:
             print("Pure Integer case is not considered here only the Mixed case!!!")
 
-    def __post_init__(self):
+        if post_process:
+            self.post_process()
+
+    def post_process(self):
         """Called after __init__ this is used as a post-processing step after the dataclass generated __init__."""
         if self.equality_indices is None:
             self.equality_indices = []

--- a/src/ppopt/mpmiqp_program.py
+++ b/src/ppopt/mpmiqp_program.py
@@ -31,7 +31,7 @@ class MPMIQP_Program(MPMILP_Program):
                  A_t: numpy.ndarray,
                  b_t: numpy.ndarray, F: numpy.ndarray, binary_indices: List, c_c: Optional[numpy.ndarray] = None,
                  c_t: Optional[numpy.ndarray] = None, Q_t: Optional[numpy.ndarray] = None,
-                 equality_indices=None, solver: Solver = None):
+                 equality_indices=None, solver: Solver = None, post_process=True):
         """Initialized the MPMIQP_Program."""
         # calls MPMILP_Program's constructor to reduce out burden
 
@@ -39,9 +39,12 @@ class MPMIQP_Program(MPMILP_Program):
             solver = Solver()
 
         super(MPMIQP_Program, self).__init__(A, b, c, H, A_t, b_t, F, binary_indices, c_c, c_t, Q_t, equality_indices,
-                                             solver)
+                                             solver, post_process=False)
         self.Q = Q
         self.constraint_datatype_conversion()
+
+        if post_process:
+            self.post_process()
 
     def evaluate_objective(self, x: numpy.ndarray, theta_point: numpy.ndarray):
         """Evaluates the objective f(x,theta)"""

--- a/src/ppopt/mpqp_program.py
+++ b/src/ppopt/mpqp_program.py
@@ -30,16 +30,17 @@ class MPQP_Program(MPLP_Program):
                  A_t: numpy.ndarray,
                  b_t: numpy.ndarray, F: numpy.ndarray, c_c: Optional[numpy.ndarray] = None,
                  c_t: Optional[numpy.ndarray] = None, Q_t: Optional[numpy.ndarray] = None,
-                 equality_indices=None, solver=None):
+                 equality_indices=None, solver=None, post_process=True):
         """Initialized the MPQP_Program."""
         # calls MPLP_Program's constructor to reduce out burden
         self.Q = Q
-        super(MPQP_Program, self).__init__(A, b, c, H, A_t, b_t, F, c_c, c_t, Q_t, equality_indices, solver)
+        super(MPQP_Program, self).__init__(A, b, c, H, A_t, b_t, F, c_c, c_t, Q_t, equality_indices, solver, post_process = False)
 
         # assignees member variables
         self.constraint_datatype_conversion()
         # calls the MPLP __post_init__ to handle equality constraints
-        # super(MPQP_Program, self).__post_init__()
+        if post_process:
+            self.post_process()
 
     def evaluate_objective(self, x, theta_point):
         r"""

--- a/src/ppopt/solution.py
+++ b/src/ppopt/solution.py
@@ -184,3 +184,9 @@ class Solution:
 
     def is_mixed_integer_sol(self):
         return isinstance(self.program, (MPMILP_Program, MPMIQP_Program))
+
+    def __len__(self):
+        """
+        Overloads the len operator and returns the number of critical regions in the solution
+        """
+        return len(self.critical_regions)

--- a/src/ppopt/solver_interface/cvxopt_interface.py
+++ b/src/ppopt/solver_interface/cvxopt_interface.py
@@ -30,19 +30,14 @@ def process_cvxopt_solution(sol, equality_constraints, inequality_constraints, n
         lagrange[equality_constraints] = -numpy.array(sol['y']).flatten()
     lagrange[inequality_constraints] = -numpy.array(sol['z']).flatten()
 
-    active = []
-
-    for i in range(num_constraints):
-        if abs(slack[i]) <= 10 ** -10 or lagrange[i] != 0:
-            active.append(i)
-
-    active = numpy.array(active)
+    non_zero_duals = numpy.where(lagrange != 0)[0]
+    active_set = numpy.array([i for i in range(num_constraints) if i in non_zero_duals or i in equality_constraints])
 
     if not get_duals:
         lagrange = None
 
     return SolverOutput(obj=sol['primal objective'], sol=numpy.array(sol['x']).flatten(), slack=slack,
-                        active_set=active,
+                        active_set=active_set,
                         dual=lagrange)
 
 

--- a/src/ppopt/solver_interface/daqp_solver_interface.py
+++ b/src/ppopt/solver_interface/daqp_solver_interface.py
@@ -89,10 +89,8 @@ def solve_qp_daqp(Q: numpy.ndarray, c: numpy.ndarray, A: numpy.ndarray, b: numpy
     lagrange[ineq] = -lagrange[ineq]
 
     slack = b - A @ make_column(x_star)
-    active = []
 
-    for i in range(num_constraints):
-        if abs(slack[i]) <= 10 ** -10 or lagrange[i] != 0:
-            active.append(i)
+    non_zero_duals = numpy.where(lagrange != 0)[0]
+    active_set = numpy.array([i for i in range(num_constraints) if i in non_zero_duals or i in equality_constraints])
 
-    return SolverOutput(opt, x_star, slack.flatten(), numpy.array(active).astype('int64'), lagrange)
+    return SolverOutput(opt, x_star, slack.flatten(), numpy.array(active_set).astype('int64'), lagrange)

--- a/src/ppopt/solver_interface/quad_prog_interface.py
+++ b/src/ppopt/solver_interface/quad_prog_interface.py
@@ -66,18 +66,17 @@ def solve_qp_quadprog(Q: numpy.ndarray, c: numpy.ndarray, A: numpy.ndarray, b: n
         x_star = sol[0]
         opt = sol[1]
         duals = sol[4]
-        active = []
+        # active = []
         indexing = [*equality_constraints, *ineq]
         lagrange[indexing] = duals
         lagrange[ineq] = -lagrange[ineq]
 
         slack = b - A @ make_column(x_star)
 
-        for i in range(num_constraints):
-            if abs(slack[i]) <= 10 ** -10 or lagrange[i] != 0:
-                active.append(i)
+        non_zero_duals = numpy.where(lagrange != 0)[0]
+        active_set = numpy.array([i for i in range(num_constraints) if i in non_zero_duals or i in equality_constraints])
 
-        return SolverOutput(opt, x_star, slack.flatten(), numpy.array(active).astype('int64'), lagrange)
+        return SolverOutput(opt, x_star, slack.flatten(), numpy.array(active_set).astype('int64'), lagrange)
 
     except ValueError:
         # just swallow the error as something happened Infeasibility or non-symmetry

--- a/src/ppopt/utils/constraint_utilities.py
+++ b/src/ppopt/utils/constraint_utilities.py
@@ -183,7 +183,8 @@ def calculate_redundant_constraints(A, b):
     return output
 
 
-def find_redundant_constraints(A: numpy.ndarray, b: numpy.ndarray, equality_set: Optional[List[int]] = None, solver='gurobi'):
+def find_redundant_constraints(A: numpy.ndarray, b: numpy.ndarray, equality_set: Optional[List[int]] = None,
+                               solver='gurobi'):
     """"""
     if equality_set is None:
         equality_set = []
@@ -310,7 +311,6 @@ def shuffle_processed_constraints(A: numpy.ndarray, b: numpy.ndarray, F: numpy.n
     F = F[kept]
 
     return A, b, F, A_t, b_t
-
 
 
 def get_independent_rows(A):

--- a/src/ppopt/utils/constraint_utilities.py
+++ b/src/ppopt/utils/constraint_utilities.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 import numpy
 
 from ..solver_interface import solver_interface
-from ..utils.general_utils import ppopt_block
+from ..utils.general_utils import ppopt_block, select_not_in_list
 
 
 # returns the norm of the constraint
@@ -310,6 +310,56 @@ def shuffle_processed_constraints(A: numpy.ndarray, b: numpy.ndarray, F: numpy.n
     F = F[kept]
 
     return A, b, F, A_t, b_t
+
+
+
+def get_independent_rows(A):
+    """
+    Finds the linearly independent rows of a matrix, A and returns the indices of these rows
+
+    :param A: The matrix to find the linearly independent rows of
+    :return: The indices of the linearly independent rows
+    """
+    num_rows = A.shape[0]
+    row_ranks = numpy.zeros(num_rows)
+    for i in range(num_rows - 1):
+        row_ranks[i] = numpy.linalg.matrix_rank(A[:i + 1])
+    rank_change = numpy.diff(row_ranks, prepend=0) > 0
+    return [index for index, val in enumerate(rank_change) if val]  # select these rows as they are linear independent
+
+
+def generate_reduced_equality_constraints(A, b, F, equality_indices):
+    """
+    Generates a reduced set of equality constraints that are linearly independent and full rank from the original set of
+    equality constraints
+
+    :param A: The LHS constraint matrix for main body constraints
+    :param b: the RHS constraint vector for main body constraints
+    :param F: the RHS parametric uncertainty matrix in the main body constraints
+    :param equality_indices: The indices of the equality constraints
+    :return: The filtered constraint matrix set A, b, F and the new equality set
+    """
+    # if there are no equality constraints, then we can just return the original constraints
+    if len(equality_indices) == 0:
+        return A, b, F, []
+
+    # if there are equality constraints, but they are full rank, then we can just return the original constraints
+    if is_full_rank(A, equality_indices):
+        return A, b, F, equality_indices
+
+    # we are in the situation where we have equality constraints that are not full rank
+    new_equality_indices = get_independent_rows(A[equality_indices])
+
+    A_eq = A[new_equality_indices]
+    b_eq = b[new_equality_indices]
+    F_eq = F[new_equality_indices]
+
+    A_ineq = select_not_in_list(A, equality_indices)
+    b_ineq = select_not_in_list(b, equality_indices)
+    F_ineq = select_not_in_list(F, equality_indices)
+
+    return numpy.block([[A_eq], [A_ineq]]), numpy.block([[b_eq], [b_ineq]]), numpy.block(
+        [[F_eq], [F_ineq]]), new_equality_indices
 
 
 def process_program_constraints(A: numpy.ndarray, b: numpy.ndarray, F: numpy.ndarray, A_t: numpy.ndarray,

--- a/tests/other_tests/test_mp_program.py
+++ b/tests/other_tests/test_mp_program.py
@@ -57,7 +57,7 @@ def simple_qp_program() -> MPQP_Program:
     A_t = numpy.array([[-1], [1]])
     b_t = numpy.array([[0], [1]])
     H = numpy.zeros((F.shape[1], Q.shape[0]))
-    return MPQP_Program(A, b, c, H, Q, A_t, b_t, F)
+    return MPQP_Program(A, b, c, H, Q, A_t, b_t, F, post_process=False)
 
 
 def test_active_set(linear_program):
@@ -209,11 +209,12 @@ def test_latex(quadratic_program):
 def test_solve_theta_mpqp_1(simple_qp_program):
     theta = numpy.array([[.5]])
     soln = simple_qp_program.solve_theta(theta)
-    print(soln)
+    print(soln, simple_qp_program.A, simple_qp_program.F)
+
     assert numpy.allclose(soln.sol, numpy.array([0]))
     assert numpy.allclose(soln.dual, numpy.array([0, 0]))
     assert numpy.allclose(soln.slack, numpy.array([5.5, 0]))
-    assert numpy.allclose(soln.active_set, numpy.array([1]))
+    assert numpy.allclose(soln.active_set, numpy.array([]))
 
 ################
 # mpLP programming

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -101,7 +101,7 @@ def quadratic_program() -> MPQP_Program:
     CRb = numpy.array([1000, 1000, 0, 0]).reshape(4, 1)
     H = numpy.zeros((F.shape[1], Q.shape[0]))
 
-    prog = MPQP_Program(A, b, c, H, Q, CRa, CRb, F)
+    prog = MPQP_Program(A, b, c, H, Q, CRa, CRb, F, post_process=False)
     prog.scale_constraints()
     return prog
 


### PR DESCRIPTION
This PR to fix bugs relating to handling of active sets and equality constraints that would induce active sets that are not full rank, both in problem definitions and in subproblem solvers. 

This does change the behavior of active set reporting when there is primal degeneracy, where as there are multiple active sets that can describe a point, then it will pick the one that is supported by the multipliers begin non-zero. 