### PR TITLE
Fix dimension error in generating substitute problem of mp-MIQP with fixed binaries

### DIFF
--- a/src/ppopt/mpmiqp_program.py
+++ b/src/ppopt/mpmiqp_program.py
@@ -85,7 +85,7 @@ class MPMIQP_Program(MPMILP_Program):
         Q_d = self.Q[:, self.binary_indices][self.binary_indices]
 
         H_alpha = self.Q[:, self.cont_indices][self.binary_indices]
-        c = self.c[self.cont_indices] + fixed_combination.T @ H_alpha
+        c = self.c[self.cont_indices] + (H_alpha.T@fixed_combination)
         c_c = self.c_c + self.c[
             self.binary_indices].T @ fixed_combination + 0.5 * fixed_combination.T @ Q_d @ fixed_combination
         H_c = self.H[self.cont_indices]

--- a/tests/mpmiqp_solver_tests/test_mpmiqp.py
+++ b/tests/mpmiqp_solver_tests/test_mpmiqp.py
@@ -3,8 +3,9 @@
 import numpy
 
 from src.ppopt.mp_solvers.solve_mpmiqp import solve_mpmiqp
+from src.ppopt.mp_solvers.solve_mpqp import mpqp_algorithm
 from src.ppopt.mpmilp_program import MPMILP_Program
-from tests.test_fixtures import simple_mpMILP, simple_mpMIQP, mpMILP_market_problem
+from tests.test_fixtures import simple_mpMILP, simple_mpMIQP, mpMILP_market_problem, mpMIQP_market_problem
 
 
 def test_mpmilp_process_constraints(simple_mpMILP):
@@ -47,6 +48,10 @@ def test_mpmilp_enumeration_solve(simple_mpMILP):
 def test_mpmilqp_enumeration_solve(simple_mpMIQP):
 
     sol = solve_mpmiqp(simple_mpMIQP)
+
+def test_mpmilqp_enumeration_solve_2(mpMIQP_market_problem):
+
+    sol = solve_mpmiqp(mpMIQP_market_problem, cont_algo=mpqp_algorithm.combinatorial)
 
 def test_mpmilp_evaluate(mpMILP_market_problem):
 

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -234,3 +234,23 @@ def mpMILP_market_problem():
 
     milp_prog = MPMILP_Program(A, b, c, H, A_t, b_t, F, binary_indices)
     return milp_prog
+
+@pytest.fixture()
+def mpMIQP_market_problem():
+    """Simple mpMIQP for Seatle-to-Topeka"""
+
+    A = numpy.array(
+        [[1, 1, 0, 0, 0], [0, 0, 1, 1, 0], [-1, 0, -1, 0, 0], [0, -1, 0, -1, -500], [-1, 0, 0, 0, 0], [0, -1, 0, 0, 0],
+         [0, 0, -1, 0, 0], [0, 0, 0, -1, 0], [0, 0, 0, 0, -1], [0, 0, 0, 0, 1]], float)
+    b = numpy.array([350, 600, 0, 0, 0, 0, 0, 0, 0, 1], float).reshape(-1, 1)
+    F = numpy.array([[0, 0], [0, 0], [-1, 0], [0, -1], [0, 0], [0, 0], [0, 0], [0, 0], [0, 0], [0, 0]], float)
+    A_t = numpy.array([[1.0, 0.0], [0.0, 1.0], [-1.0, 0.0], [0.0, -1.0]], float)
+    b_t = numpy.array([[1000.0], [1000.0], [0.0], [0.0]], float)
+    H = numpy.zeros([5, 2])
+    binary_indices = [4]
+
+    Q = numpy.diag([153, 162, 162, 126, 1])
+    c = numpy.array([25, 25, 25, 25, 7.6e6]).reshape(-1, 1)
+
+    miqp_prog = MPMIQP_Program(A, b, c, H, Q, A_t, b_t, F, binary_indices)
+    return miqp_prog


### PR DESCRIPTION
Found a test case which broke the current implementation, fixed dimensions in computation so it should now be correct. Added the example as a new test.