### PR TITLE
Fixes a performance bug when checking for nonzero rows while generating CRs

### DIFF
--- a/src/ppopt/utils/constraint_utilities.py
+++ b/src/ppopt/utils/constraint_utilities.py
@@ -471,6 +471,6 @@ def numerically_nonzero_rows(A) -> List[int]:
 
 
 def remove_numerically_zero_rows(A, b) -> (numpy.ndarray, numpy.ndarray):
-    keep = [i for i in range(A.shape[0]) if i in numerically_nonzero_rows(A)]
-
+    num_nonzero = numerically_nonzero_rows(A)
+    keep = [i for i in range(A.shape[0]) if i in num_nonzero]
     return A[keep], b[keep]


### PR DESCRIPTION
In the ``remove_numerically_zero_rows`` utility function, we are repeated calling another helper function. 


```python
def remove_numerically_zero_rows(A, b) -> (numpy.ndarray, numpy.ndarray):
    keep = [i for i in range(A.shape[0]) if i in numerically_nonzero_rows(A)]
    return A[keep], b[keep]
```

This is inefficient and for larger problems, can consume the fast majority of the time to build the critical region. For example, when considering the problem from [Robust Scheduling of Energy Systems Under Forecasting Uncertainty–A Multi-Parametric Optimization Approach](https://www.sciencedirect.com/science/article/pii/B978044328824150209X), this takes 99% of the computational burden of generating the explicit solution or in other words we can massively speed up larger problems by just caching.