### PR TITLE
Fix rendering of scientific notation in latex output

### DIFF
--- a/src/ppopt/utils/general_utils.py
+++ b/src/ppopt/utils/general_utils.py
@@ -48,9 +48,12 @@ def render_number(x, trade_off=1e-4) -> str:
     elif abs(x) > trade_off:
         return f"{float(x):.4}"
     else:
-        base_10 = numpy.log10(abs(x))
+        base_10 = int(numpy.floor(numpy.log10(abs(x))))
+
         exponent = 10 ** base_10
-        return f"{x / exponent:.4} " + "10^{" + f"{exponent}" + "}"
+        x_scaled = x / exponent
+
+        return f"{x_scaled:.4} " + "10^{" + f"{base_10}" + "}"
 
 
 def latex_matrix(A: Union[List[str], numpy.ndarray]) -> str:


### PR DESCRIPTION
Closed #41 by fixing the scientific notation path of ``render_number`` in ``general_utils.py``. Will now properly display the numbers as given.