### PR TITLE
Adds relaxation feature to mpMIQPs and mpMILPs

### DIFF
--- a/src/ppopt/mp_solvers/mpmiqp_enumeration.py
+++ b/src/ppopt/mp_solvers/mpmiqp_enumeration.py
@@ -18,6 +18,8 @@ def solve_mpmiqp_enumeration(program: MPMILP_Program, num_cores: int = -1,
     2) Solving the resulting continuous mpQP/mpLP sub-problems for every feasible binary combination
     3) Merging all solutions together
 
+    This algorithm is quite slow in the general sense, but can solve a rich class of problems.
+
     :param program: An mpQP/mpLP of a problem with the binary variables without added constraints for the binary variables
     :param num_cores: the number of cores to use in this calculation to solve the mpLP/mpQP sub-problems
     :param cont_algorithm: the algorithm to solve the mpLP/mpQP algorithms (might not be required)

--- a/src/ppopt/utils/region_overlap_utils.py
+++ b/src/ppopt/utils/region_overlap_utils.py
@@ -94,7 +94,7 @@ def identify_overlaps_1d(program: MPMILP_Program, regions: List[CriticalRegion])
 
     # remove numerically nil regions
     region_bounds = [get_bounds_1d(cr.E, cr.f) for cr in regions]
-    regions = [ cr for cr, bounds in zip(regions, region_bounds) if abs(bounds[0]- bounds[1]) > 1e-8]
+    regions = [cr for cr, bounds in zip(regions, region_bounds) if abs(bounds[0]- bounds[1]) > 1e-8]
 
     return possible_dual_degeneracy, regions
 

--- a/tests/mpmiqp_solver_tests/test_mpmiqp.py
+++ b/tests/mpmiqp_solver_tests/test_mpmiqp.py
@@ -2,7 +2,7 @@
 import numpy
 
 from src.ppopt.mp_solvers.solve_mpmiqp import solve_mpmiqp
-from src.ppopt.mp_solvers.solve_mpqp import mpqp_algorithm
+from src.ppopt.mp_solvers.solve_mpqp import mpqp_algorithm, solve_mpqp
 from tests.test_fixtures import simple_mpMILP, simple_mpMIQP, mpMILP_market_problem, mpMIQP_market_problem, \
     bard_mpMILP_adapted, bard_mpMILP_adapted_2, bard_mpMILP_adapted_degenerate, mpMILP_1d, acevedo_mpmilp, \
     pappas_multi_objective, pappas_multi_objective_2
@@ -142,6 +142,7 @@ def test_pappas_mpmilp(pappas_multi_objective):
 
     assert (len(sol) == 3)
 
+
 def test_pappas_mpmilp_2(pappas_multi_objective_2):
     sol = solve_mpmiqp(pappas_multi_objective_2, num_cores=1)
 
@@ -150,9 +151,8 @@ def test_pappas_mpmilp_2(pappas_multi_objective_2):
     theta_sol = sol.evaluate(theta_point)
     theta_obj = sol.evaluate_objective(theta_point)
 
-    # determanistic solution at theta = 90
+    # deterministic solution at theta = 90
     det_sol = pappas_multi_objective_2.solve_theta(theta_point)
 
     assert numpy.allclose(theta_sol.flatten(), det_sol.sol)
     assert numpy.allclose(theta_obj, det_sol.obj)
-

--- a/tests/mpmiqp_solver_tests/test_mpmiqp.py
+++ b/tests/mpmiqp_solver_tests/test_mpmiqp.py
@@ -5,7 +5,7 @@ from src.ppopt.mp_solvers.solve_mpmiqp import solve_mpmiqp
 from src.ppopt.mp_solvers.solve_mpqp import mpqp_algorithm
 from tests.test_fixtures import simple_mpMILP, simple_mpMIQP, mpMILP_market_problem, mpMIQP_market_problem, \
     bard_mpMILP_adapted, bard_mpMILP_adapted_2, bard_mpMILP_adapted_degenerate, mpMILP_1d, acevedo_mpmilp, \
-    pappas_multi_objective
+    pappas_multi_objective, pappas_multi_objective_2
 from src.ppopt.utils.mpqp_utils import get_bounds_1d
 
 
@@ -141,3 +141,18 @@ def test_pappas_mpmilp(pappas_multi_objective):
     sol = solve_mpmiqp(pappas_multi_objective, num_cores=1)
 
     assert (len(sol) == 3)
+
+def test_pappas_mpmilp_2(pappas_multi_objective_2):
+    sol = solve_mpmiqp(pappas_multi_objective_2, num_cores=1)
+
+    theta_point = numpy.array([[90.0]])
+
+    theta_sol = sol.evaluate(theta_point)
+    theta_obj = sol.evaluate_objective(theta_point)
+
+    # determanistic solution at theta = 90
+    det_sol = pappas_multi_objective_2.solve_theta(theta_point)
+
+    assert numpy.allclose(theta_sol.flatten(), det_sol.sol)
+    assert numpy.allclose(theta_obj, det_sol.obj)
+

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -502,3 +502,34 @@ def pappas_multi_objective():
     m.add_constrs(x[i] <= 100 for i in range(1, 3))
 
     return m.formulate_problem()
+
+@pytest.fixture()
+def pappas_multi_objective_2():
+    """
+    This is modification of the  MP-MILP problem from the paper "Multiobjective Optimization of Mixed-Integer Linear
+    Programming Problems: A Multiparametric Optimization Approach" by Pappas et al. 2021, the numerical example in
+    section 3. Here the constraint is changed from y1 + y2 <= 1 -> y1 + y2 = 1
+    """
+
+    m = MPModeler()
+    x = {i: m.add_var(name=f'x_[{i}]') for i in range(1, 3)}
+    y = {i: m.add_var(name=f'y_[{i}]', vtype=VariableType.binary) for i in range(1, 3)}
+    e = m.add_param(name=f'e')
+
+    # cost function
+    m.set_objective(0.2 * x[1] - 0.48 * x[2] - 55 * y[1] - 20.7 * y[2])
+
+    # constraints
+    m.add_constr(11.01* x[1] + 0.49*x[2] + 52.4*y[1] + 24.8*y[2] <= e)
+    m.add_constr(0.07*x[1] - x[2] <= 1.78)
+
+    m.add_constr(-0.87*x[1] - 0.5*x[2] + 0.02*y[1] <= 0.05)
+    m.add_constr(y[1] + y[2] == 1)
+
+    m.add_constr(e >= 0)
+    m.add_constr(e <= 101.4)
+
+    m.add_constrs(x[i] >= 0 for i in range(1, 3))
+    m.add_constrs(x[i] <= 100 for i in range(1, 3))
+
+    return m.formulate_problem()


### PR DESCRIPTION
This adds a relaxation feature to the mpMIQP and mpMILP classes, so it is direct to generate relaxations from their mixed integer analogs. 

In addition this fixes an error on the generating fixed binary substitutions of mpMIPs.