### PR TITLE
Improve mpQP explicit control law numerics again 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-__version__ = "1.6.6"
+__version__ = "1.6.7"
 
 short_desc = (
     "Extensible Multiparametric Solver in Python"
@@ -20,7 +20,7 @@ setup(
     license='MIT',
     url='https://github.com/TAMUparametric/PPOPT',
     extras_require={
-        'test': ['pytest'],
+        'test': ['pytest', 'cvxopt', 'quadprog'],
         'optional': ['cvxopt', 'quadprog'],
     },
     install_requires=["numpy",


### PR DESCRIPTION
In the last change to mpQP explicit control law, we improved it by removing the matrix inverses and having it in terms of linear solves. However, there is still a dependence and a path to accumulate errors. While the last update reduced gross errors down, there is still a chain of linear solves, and thus a path to accumulate error. 

This new method, reduces numerical error further by having all parameters directly generated from via one linear solve. This massively reduces the error compared to the original implementation, and the newer implementation.