### PR TITLE
Bump version number for new pypi release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-__version__ = "1.6.7"
+__version__ = "1.6.8"
 
 short_desc = (
     "Extensible Multiparametric Solver in Python"


### PR DESCRIPTION
This bumps the version number in preparation to release a new version pypi from main, to move the mpLP specialization code for combinatorial and improved numerics.