### PR TITLE
Adds method for overdetermined active sets for geometric algorithm

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-__version__ = "1.6.8"
+__version__ = "1.6.9"
 
 short_desc = (
     "Extensible Multiparametric Solver in Python"

--- a/src/ppopt/solver_interface/cvxopt_interface.py
+++ b/src/ppopt/solver_interface/cvxopt_interface.py
@@ -32,14 +32,22 @@ def process_cvxopt_solution(sol, equality_constraints, inequality_constraints, n
         lagrange[equality_constraints] = -numpy.array(sol['y']).flatten()
     lagrange[inequality_constraints] = -numpy.array(sol['z']).flatten()
 
-    non_zero_duals = numpy.where(lagrange != 0)[0]
-    active_set = numpy.array([i for i in range(num_constraints) if i in non_zero_duals or i in equality_constraints])
+    active = []
+
+    for i in range(num_constraints):
+        if abs(slack[i]) <= 10 ** -10 or lagrange[i] != 0:
+            active.append(i)
+
+    active = numpy.array(active)
+
+    # non_zero_duals = numpy.where(lagrange != 0)[0]
+    # active_set = numpy.array([i for i in range(num_constraints) if i in non_zero_duals or i in equality_constraints])
 
     if not get_duals:
         lagrange = None
 
     return SolverOutput(obj=sol['primal objective'], sol=numpy.array(sol['x']).flatten(), slack=slack,
-                        active_set=active_set,
+                        active_set=active,
                         dual=lagrange)
 
 

--- a/src/ppopt/solver_interface/daqp_solver_interface.py
+++ b/src/ppopt/solver_interface/daqp_solver_interface.py
@@ -93,7 +93,13 @@ def solve_qp_daqp(Q: numpy.ndarray, c: Matrix, A: Matrix, b: Matrix,
 
     slack = b - A @ make_column(x_star)
 
-    non_zero_duals = numpy.where(lagrange != 0)[0]
-    active_set = numpy.array([i for i in range(num_constraints) if i in non_zero_duals or i in equality_constraints])
+    active = []
 
-    return SolverOutput(opt, x_star, slack.flatten(), numpy.array(active_set).astype('int64'), lagrange)
+    for i in range(num_constraints):
+        if abs(slack[i]) <= 10 ** -10 or lagrange[i] != 0:
+            active.append(i)
+
+    # non_zero_duals = numpy.where(lagrange != 0)[0]
+    # active_set = numpy.array([i for i in range(num_constraints) if i in non_zero_duals or i in equality_constraints])
+
+    return SolverOutput(opt, x_star, slack.flatten(), numpy.array(active).astype('int64'), lagrange)

--- a/src/ppopt/solver_interface/gurobi_solver_interface.py
+++ b/src/ppopt/solver_interface/gurobi_solver_interface.py
@@ -132,14 +132,7 @@ def solve_miqp_gurobi(Q: Matrix = None, c: Matrix = None, A: Matrix = None,
                 sol.dual = numpy.array(model.getAttr("Pi"))
 
         sol.slack = numpy.array(model.getAttr("Slack"))
-
-        if sol.dual is not None:
-            # we have a continuous problem, and we can get the duals directly
-            non_zero_duals = numpy.where(sol.dual != 0)[0]
-            sol.active_set = numpy.array(
-                [i for i in range(num_constraints) if i in non_zero_duals or i in equality_constraints])
-        else:
-            sol.active_set = numpy.where((A @ sol.sol.flatten() - b.flatten()) ** 2 < 10 ** -12)[0]
+        sol.active_set = numpy.where((A @ sol.sol.flatten() - b.flatten()) ** 2 < 10 ** -12)[0]
 
     return sol
 

--- a/src/ppopt/solver_interface/quad_prog_interface.py
+++ b/src/ppopt/solver_interface/quad_prog_interface.py
@@ -68,18 +68,21 @@ def solve_qp_quadprog(Q: numpy.ndarray, c: numpy.ndarray, A: numpy.ndarray, b: n
         x_star = sol[0]
         opt = sol[1]
         duals = sol[4]
-        # active = []
+        active = []
         indexing = [*equality_constraints, *ineq]
         lagrange[indexing] = duals
         lagrange[ineq] = -lagrange[ineq]
 
         slack = b - A @ make_column(x_star)
+        for i in range(num_constraints):
+            if abs(slack[i]) <= 10 ** -10 or lagrange[i] != 0:
+                active.append(i)
 
-        non_zero_duals = numpy.where(lagrange != 0)[0]
-        active_set = numpy.array(
-            [i for i in range(num_constraints) if i in non_zero_duals or i in equality_constraints])
+        # non_zero_duals = numpy.where(lagrange != 0)[0]
+        # active_set = numpy.array(
+        #     [i for i in range(num_constraints) if i in non_zero_duals or i in equality_constraints])
 
-        return SolverOutput(opt, x_star, slack.flatten(), numpy.array(active_set).astype('int64'), lagrange)
+        return SolverOutput(opt, x_star, slack.flatten(), numpy.array(active).astype('int64'), lagrange)
 
     except ValueError:
         # just swallow the error as something happened Infeasibility or non-symmetry

--- a/tests/other_tests/test_solve_mpqp.py
+++ b/tests/other_tests/test_solve_mpqp.py
@@ -3,7 +3,7 @@ import numpy
 from src.ppopt.utils.chebyshev_ball import chebyshev_ball
 from src.ppopt.mp_solvers import mpqp_parrallel_combinatorial
 from src.ppopt.mp_solvers.solve_mpqp import mpqp_algorithm, solve_mpqp
-from tests.test_fixtures import qp_problem, simple_mpLP, portfolio_problem_analog, non_negative_least_squares
+from tests.test_fixtures import qp_problem, simple_mpLP, portfolio_problem_analog, non_negative_least_squares, over_determined_as_mplp
 
 
 def test_solve_mpqp_combinatorial(qp_problem):
@@ -83,6 +83,12 @@ def test_solve_mplp_combinatorial(simple_mpLP):
     solution = solve_mpqp(simple_mpLP, mpqp_algorithm.combinatorial)
     assert solution is not None
     assert len(solution.critical_regions) == 4
+
+def tesT_solve_mplp_overdetermined_active_set(over_determined_as_mplp):
+
+    solution = solve_mpqp(over_determined_as_mplp, mpqp_algorithm.combinatorial)
+    assert solution is not None
+    assert len(solution.critical_regions) == 5
 
 
 def test_solve_missing_algorithm(qp_problem):

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -533,3 +533,27 @@ def pappas_multi_objective_2():
     m.add_constrs(x[i] <= 100 for i in range(1, 3))
 
     return m.formulate_problem()
+
+@pytest.fixture()
+def over_determined_as_mplp():
+    """
+    The relaxation of this mpMILP was found to generate over determined active sets in some regions of the parametric
+    space. So it would cause problems with incomplete solutions.
+
+    """
+    A = numpy.array(
+        [[1, 1, 0, 0, 0], [0, 0, 1, 1, 0], [-1, 0, -1, 0, 0], [0, -1, 0, -1, -500], [-1, 0, 0, 0, 0], [0, -1, 0, 0, 0],
+         [0, 0, -1, 0, 0], [0, 0, 0, -1, 0], [0, 0, 0, 0, -1], [0, 0, 0, 0, 1]], float)
+    b = numpy.array([350, 600, 0, 0, 0, 0, 0, 0, 0, 1], float).reshape(-1, 1)
+    F = numpy.array([[0, 0], [0, 0], [-1, 0], [0, -1], [0, 0], [0, 0], [0, 0], [0, 0], [0, 0], [0, 0]], float)
+    A_t = numpy.array([[1.0, 0.0], [0.0, 1.0], [-1.0, 0.0], [0.0, -1.0]], float)
+    b_t = numpy.array([[1000.0], [1000.0], [0.0], [0.0]], float)
+    H = numpy.zeros([5, 2])
+    binary_indices = [4]
+
+    Q = 2 * numpy.diag([153, 162, 162, 126, 0.1])
+    c = numpy.array([25, 25, 25, 25, 100]).reshape(-1, 1)
+
+    miqp_prog = MPMILP_Program(A, b, c, H, A_t, b_t, F, binary_indices)
+
+    return miqp_prog.generate_relaxed_problem()


### PR DESCRIPTION
This reverts a change and redefines active set based on the constraints that are touched, instead of the new definition where it is based on the nonzero multipliers. This caused problems for the geometric algorithm, when in entire domains of the parametric space there are overdetermined regions in the touching definition while underdetermined in the multiplier definition. 

This reverts back to the initial definition, and then adds a method to handle the the overdetermined active sets, in that we find a subset of the active set that is full rank. This should make the geometric algorithm more stable in general.