### PR TITLE
Moving program warnings to not print to std out

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-__version__ = "1.6.8"
+__version__ = "1.6.10"
 
 short_desc = (
     "Extensible Multiparametric Solver in Python"

--- a/src/ppopt/mp_solvers/mpqp_parallel_combinatorial_exp.py
+++ b/src/ppopt/mp_solvers/mpqp_parallel_combinatorial_exp.py
@@ -131,6 +131,6 @@ def solve(program: MPQP_Program, num_cores=-1) -> Solution:
         if len(to_check) == 0:
             break
 
-    pool.clear()
+    # pool.clear()
 
     return solution

--- a/src/ppopt/mp_solvers/mpqp_parallel_geometric_exp.py
+++ b/src/ppopt/mp_solvers/mpqp_parallel_geometric_exp.py
@@ -167,6 +167,6 @@ def solve(program: MPQP_Program, initial_active_sets: Optional[List[List[int]]] 
                 work_items.extend(
                     [(theta, facet_normal, radius, found_cr.active_set) for theta, facet_normal, radius in facets])
 
-    pool.clear()
+    # pool.clear()
 
     return solution

--- a/src/ppopt/mp_solvers/mpqp_parrallel_combinatorial.py
+++ b/src/ppopt/mp_solvers/mpqp_parrallel_combinatorial.py
@@ -145,6 +145,6 @@ def solve(program: MPQP_Program, num_cores=-1) -> Solution:
             if region is not None:
                 solution.add_region(region)
 
-    pool.clear()
+    # pool.clear()
 
     return solution

--- a/src/ppopt/mplp_program.py
+++ b/src/ppopt/mplp_program.py
@@ -101,7 +101,7 @@ class MPLP_Program:
 
         # print warnings if there are any
         for warning in problem_warning:
-            warnings.warn(warning)
+            warnings.warn(warning, UserWarning)
 
         # calls constraint processing to remove redundant constraints
         if post_process:

--- a/src/ppopt/mplp_program.py
+++ b/src/ppopt/mplp_program.py
@@ -1,6 +1,7 @@
 from typing import List, Optional, Tuple
 
 import numpy
+import warnings
 
 from .solver import Solver
 from .solver_interface.solver_interface_utils import SolverOutput
@@ -96,11 +97,11 @@ class MPLP_Program:
         self.base_constraint_processing()
 
         # grab all warnings
-        warnings = self.warnings()
+        problem_warning = self.warnings()
 
         # print warnings if there are any
-        if len(warnings) > 0:
-            print(warnings)
+        for warning in problem_warning:
+            warnings.warn(warning)
 
         # calls constraint processing to remove redundant constraints
         if post_process:

--- a/tests/mpqp_solver_tests/test_mpqp_combinatorial.py
+++ b/tests/mpqp_solver_tests/test_mpqp_combinatorial.py
@@ -54,17 +54,17 @@ def test_generate_children_4(filled_combo_tester):
     assert output == [[0, 4], [0, 5], [0, 6], [0, 7]]
 
 
-def test_generate_children_5(blank_combo_tester, linear_program):
-    output = generate_children_sets(linear_program.equality_indices, linear_program.num_constraints(), blank_combo_tester)
+def test_generate_children_5(blank_combo_tester):
+    output = generate_children_sets([0], 3, blank_combo_tester)
     assert output == [[0, 1], [0, 2]]
 
 
-def test_generate_children_6(blank_combo_tester, linear_program):
-    output = generate_children_sets([0, 1], linear_program.num_constraints(), blank_combo_tester)
+def test_generate_children_6(blank_combo_tester):
+    output = generate_children_sets([0, 1], 3, blank_combo_tester)
     assert output == [[0, 1, 2]]
 
 
-def test_generate_children_7(blank_combo_tester, linear_program):
+def test_generate_children_7(blank_combo_tester):
     A = numpy.array(
         [[1, 1, 0, 0], [0, 0, 1, 1], [-1, 0, -1, 0], [0, -1, 0, -1], [-1, 0, 0, 0], [0, -1, 0, 0], [0, 0, -1, 0],
          [0, 0, 0, -1]])
@@ -74,9 +74,9 @@ def test_generate_children_7(blank_combo_tester, linear_program):
     Q = numpy.diag([153, 162, 162, 126])
 
     CRa = numpy.vstack((numpy.eye(2), -numpy.eye(2)))
-    CRb = numpy.array([1000, 1000, 0, 0]).reshape(4, 1)
+    CRb = numpy.array([1000, 1000, 0, 0]).reshape(-1, 1)
     H = numpy.zeros((F.shape[1], Q.shape[0]))
-    program = MPQP_Program(A, b, c, H, Q, CRa, CRb, F, equality_indices = [0])
+    program = MPQP_Program(A, b, c, H, Q, CRa, CRb, F, equality_indices=[0])
 
     output = generate_children_sets(program.equality_indices, program.num_constraints(), blank_combo_tester)
     assert output == [[0, 1], [0, 2], [0, 3], [0, 4], [0, 5], [0, 6], [0, 7]]


### PR DESCRIPTION
As brought up in #62 it is not great to print warnings directly to std out. Instead it would be nice to have it be on std err via the warnings module. 

This is a placeholder, as some of the tests are directly checking the length of the warning list generated from the problem, and now have a side interaction with pytest as pytest is finding these warnings.