### PR TITLE
Use correct deterministic solver for Geometric algorithm

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-__version__ = "1.6.11"
+__version__ = "1.6.12"
 
 short_desc = (
     "Extensible Multiparametric Solver in Python"

--- a/src/ppopt/mp_solvers/mpqp_geometric.py
+++ b/src/ppopt/mp_solvers/mpqp_geometric.py
@@ -41,7 +41,7 @@ def solve(program: MPQP_Program, active_set=None) -> Solution:
         A, b = cur_region.E, cur_region.f
 
         # we want to look at every facet on the region
-        facet_information = get_facet_centers(A, b)
+        facet_information = get_facet_centers(A, b, program.solver)
 
         for center, normal, radius in facet_information:
 

--- a/src/ppopt/mp_solvers/mpqp_parallel_geometric_exp.py
+++ b/src/ppopt/mp_solvers/mpqp_parallel_geometric_exp.py
@@ -60,7 +60,7 @@ def full_process_2(program, current_active_set):
     if critical_region is None:
         return None
 
-    return critical_region, get_facet_centers(critical_region.E, critical_region.f)
+    return critical_region, get_facet_centers(critical_region.E, critical_region.f, solver = program.solver)
 
 
 def fathem_initial_active_sets(program: MPQP_Program, initial_active_sets: List[List[int]]):
@@ -78,7 +78,7 @@ def fathem_initial_active_sets(program: MPQP_Program, initial_active_sets: List[
     work_items = []
 
     for cr in crs:
-        facets = get_facet_centers(cr.E, cr.f)
+        facets = get_facet_centers(cr.E, cr.f, program.solver)
         work_items.extend([(theta, facet_normal, radius, cr.active_set) for theta, facet_normal, radius in facets])
 
     return work_items, crs
@@ -112,7 +112,7 @@ def solve(program: MPQP_Program, initial_active_sets: Optional[List[List[int]]] 
 
     cr_gen = lambda active_set: gen_cr_from_active_set(program=program, active_set=active_set, check_full_dim=True)
 
-    facet_gen = lambda cr: get_facet_centers(cr.E, cr.f)
+    facet_gen = lambda cr: get_facet_centers(cr.E, cr.f, program.solver)
 
     initial_critical_regions = [cr for cr in pool.map(cr_gen, initial_active_sets) if cr is not None]
     initial_facets = pool.map(facet_gen, initial_critical_regions)

--- a/src/ppopt/mp_solvers/solver_utils.py
+++ b/src/ppopt/mp_solvers/solver_utils.py
@@ -6,6 +6,7 @@ from ..critical_region import CriticalRegion
 from ..mplp_program import MPLP_Program
 from ..mpqp_program import MPQP_Program
 from ..solution import Solution
+from ..solver import Solver
 from ..utils.chebyshev_ball import chebyshev_ball
 from ..utils.general_utils import make_column
 from ..utils.mpqp_utils import gen_cr_from_active_set
@@ -202,7 +203,8 @@ def find_sub_active_set(program: Union[MPLP_Program, MPQP_Program], active_set: 
     return [*eq_cons, *kept_inequalities]
 
 
-def get_facet_centers(A: numpy.ndarray, b: numpy.ndarray) -> List[Tuple[numpy.ndarray, numpy.ndarray, float]]:
+def get_facet_centers(A: numpy.ndarray, b: numpy.ndarray, solver: Optional[Solver] = None) -> List[
+    Tuple[numpy.ndarray, numpy.ndarray, float]]:
     r"""
     This takes the polytope P, and finds all the chebychev centers and normal vectors of each facet and the radius.
 
@@ -215,6 +217,9 @@ def get_facet_centers(A: numpy.ndarray, b: numpy.ndarray) -> List[Tuple[numpy.nd
     """
     facet_centers = []
 
+    if solver is None:
+        solver = Solver()
+
     for facet_index in range(A.shape[0]):
 
         # theta point to look out of
@@ -226,7 +231,7 @@ def get_facet_centers(A: numpy.ndarray, b: numpy.ndarray) -> List[Tuple[numpy.nd
             radius = 1.0
         else:
             # We take the chebychev ball of the facet
-            chev_ball = chebyshev_ball(A, b, [facet_index])
+            chev_ball = chebyshev_ball(A, b, [facet_index], deterministic_solver=solver.solvers['lp'])
             if chev_ball is not None:
                 theta = chev_ball.sol[:-1]
                 radius = chev_ball.sol[-1]


### PR DESCRIPTION
There is a inconsistency when using the geometric solver, the LP solver that is specified by the program is ignored and instead gurobi is used by default. 

This PR fixes this issue, and takes the solver set from the program deterministic solver set. This should speed up instances, where glpk is faster then gurobi (e.g. small instances).