### PR TITLE
Add global random seed for deterministic tests

### DIFF
--- a/tests/solver_interface_tests/test_solver_consistency.py
+++ b/tests/solver_interface_tests/test_solver_consistency.py
@@ -9,6 +9,7 @@ from src.ppopt.solver_interface.gurobi_solver_interface import (
     solve_qp_gurobi,
 )
 from src.ppopt.solver_interface.quad_prog_interface import solve_qp_quadprog
+random.seed(42)
 
 
 def test_lp_consistency():


### PR DESCRIPTION
### Description

This PR introduces a global random seed set after imports in the test file. This change aims to make the tests more deterministic and easier to debug by ensuring consistent random behavior across test runs. 

I also see that you use seed for the numpy random in one test.

### Current Issues (Before this PR):

The tests currently use random without setting a fixed seed, which causes several problems :

a. Flaky Tests: Tests sometimes pass and sometimes fail due to different random values;
b. Hard to Reproduce: When a test fails, it's difficult to reproduce the exact conditions;
c. Inconsistent CI/CD: Different CI runs may have different outcomes;
d. Time Wasted: Developers spend time debugging issues that are hard to replicate.

(Im not saying these problems are happening, but they can happen.)

### Solution

Set a global random seed right after imports in the test file.

### Benefits

a. Reproducibility: All test runs will use the same random values;
b. Easier Debugging: When a test fails, we can easily reproduce the issue;
c. Consistent CI/CD: Every CI run will have the same behavior;
d. Clear Intent: It's immediately obvious that we're using controlled randomness;
e. Time Saved: Less time spent on debugging non-deterministic test failures.